### PR TITLE
Refactor: Simplify User Kanji Progress Tracking API

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,12 +86,13 @@ frontend/
   - [x] `PATCH /api/users/current`: Memperbarui nama atau password user.
   - [x] `DELETE /api/users/logout`: Menghapus token (Logout).
 - **Kanji Data**:
-  - [x] `GET /api/kanjis`: Mengambil list kanji (pagination, filter JLPT, & search karakter/makna).
+  - [x] `GET /api/kanjis`: Mengambil list kanji.
+    - Query Params: `level` (N1-N5), `search` (karakter/makna), `page`, `limit`.
   - [ ] `GET /api/kanjis/:id`: Mengambil detail satu kanji (Planned).
 - **User Progress**:
-  - [x] `POST /api/user-kanji`: Simpan/update progres hafalan (Upsert).
-  - [x] `PUT /api/user-kanji/:kanjiId`: Simpan/update progres hafalan (Upsert).
+  - [x] `POST /api/user-kanji/:kanjiId`: Simpan/update progres hafalan (Hardcoded `isMemorized: true`).
   - [x] `GET /api/user-kanji`: List progres hafalan pengguna.
+    - Query Params: `isMemorized` (boolean), `page`, `size`.
   - [x] `GET /api/user-kanji/:kanjiId`: Detail progres untuk kanji tertentu.
 
 ### Frontend Scaffolding
@@ -109,8 +110,8 @@ frontend/
 
 ## 5. File Kunci & Fungsinya
 
-- `backend/prisma/schema.prisma`: Sumber kebenaran struktur database.
-- `backend/src/application/web.js`: Jantung konfigurasi Express dan registrasi rute.
+- `backend/prisma/schema.prisma`: Source struktur database.
+- `backend/src/application/web.js`: Konfigurasi Express dan registrasi rute.
 - `backend/src/middleware/auth-middleware.js`: Menangani validasi token Bearer dan menyediakan data user di `req.user`.
 - `backend/src/error/error-middleware.js`: Menstandarisasi format error JSON (Zod, 404, 500, dll).
 
@@ -123,6 +124,7 @@ frontend/
 3. **Data Isolation**: Logika pengambilan/pembaruan data pribadi selalu menggunakan `req.user.email` untuk memastikan pengguna hanya bisa mengakses data mereka sendiri.
 4. **Validation Messaging**: Pesan error Zod dikustomisasi menggunakan Bahasa Indonesia untuk kemudahan integrasi dengan Frontend.
 5. **Multi-field Search Logic**: Pencarian kanji mendukung parameter `search` yang akan difilter menggunakan operator `OR` pada kolom `character` dan `meaning` dengan metode `contains` (substring search) untuk fleksibilitas hasil.
+6. **Simplified Progress Tracking**: Penambahan progres kanji menggunakan endpoint `POST /api/user-kanji/:kanjiId` tanpa membutuhkan request body. Hal ini menyederhanakan interaksi Frontend (Quick Add) dan status hafalan secara otomatis di-set menjadi `true`.
 
 ---
 
@@ -150,13 +152,14 @@ frontend/
 3. Duplikat `.env.example` menjadi `.env` dan sesuaikan `DATABASE_URL` (MySQL).
 4. Generate Prisma Client: `npx prisma generate`.
 5. Sinkronisasi database: `npx prisma db push`.
-6. Jalankan server dev: `npm run dev`.
+6. Jalankan server dev: `bun run dev`.
+7. Akses via browser (default): `http://localhost:5000`.
 
 ### Frontend
 
 1. Masuk ke folder frontend: `cd frontend`.
 2. Install dependensi: `npm install` atau `bun install`.
-3. Jalankan aplikasi: `npm run dev`.
+3. Jalankan aplikasi: `bun run dev`.
 4. Akses via browser (default): `http://localhost:5173`.
 
 ## 9. Konvensi Git & Kolaborasi
@@ -171,3 +174,25 @@ frontend/
 
 - Format: sama dengan judul issue yang diselesaikan
 - Contoh: `Feature: Implementasi API Get Kanji`
+
+## 10. Instruksi untuk AI Assistant
+
+### Sebelum mulai task
+
+- Baca dan pahami seluruh isi CONTEXT.md ini
+- Ikuti semua konvensi yang tertulis di sini
+- Jangan berasumsi di luar yang tertulis di CONTEXT.md
+
+### Pada saat menjalankan task
+
+- Selalu buat dokumentasinya di baris program, jelaskan kegunaan function/method dengan bahasa Indonesia yang mudah dimengerti.
+
+### Setelah selesai task
+
+- Update CONTEXT.md jika ada:
+  - API baru yang selesai diimplementasi
+  - Keputusan arsitektur baru
+  - Perubahan konvensi kode
+  - Dependency baru yang ditambahkan
+- Jangan update CONTEXT.md jika hanya bug fix kecil
+  atau perubahan yang tidak mempengaruhi arsitektur

--- a/backend/src/controller/user-kanji-controller.js
+++ b/backend/src/controller/user-kanji-controller.js
@@ -4,17 +4,18 @@ import * as userKanjiService from '../services/user-kanji-service.js';
  * Menyimpan atau memperbarui progres belajar kanji (memorized, difficulty, note).
  * Mendukung input kanjiId via body atau parameter URL.
  */
-const upsert = async (req, res, next) => {
+const add = async (req, res, next) => {
     try {
         const user = req.user;
-        const request = req.body;
+        // Inisialisasi objek request, pastikan tidak undefined jika body kosong
+        const request = req.body || {};
         
-        // Memastikan kanjiId diambil dari params jika tersedia (mendukung PUT /:kanjiId)
+        // Memastikan kanjiId diambil dari params jika tersedia
         if (req.params.kanjiId) {
             request.kanjiId = req.params.kanjiId;
         }
 
-        const result = await userKanjiService.upsert(user, request);
+        const result = await userKanjiService.add(user, request);
         res.status(200).json({
             data: result
         });
@@ -59,4 +60,4 @@ const list = async (req, res, next) => {
     }
 };
 
-export { upsert, get, list };
+export { add, get, list };

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -27,8 +27,7 @@ apiRouter.get('/api/kanjis', kanjiController.list);
 /**
  * API User Kanji: Mengelola progres belajar kanji tiap pengguna.
  */
-apiRouter.post('/api/user-kanji', userKanjiController.upsert);
-apiRouter.put('/api/user-kanji/:kanjiId', userKanjiController.upsert);
+apiRouter.post('/api/user-kanji/:kanjiId', userKanjiController.add);
 apiRouter.get('/api/user-kanji', userKanjiController.list);
 apiRouter.get('/api/user-kanji/:kanjiId', userKanjiController.get);
 

--- a/backend/src/services/user-kanji-service.js
+++ b/backend/src/services/user-kanji-service.js
@@ -1,7 +1,7 @@
 import { prisma } from '../application/database.js';
 import { ResponseError } from '../error/response-error.js';
 import {
-    createOrUpdateUserKanjiValidation,
+    addUserKanjiValidation,
     getUserKanjiValidation,
     listUserKanjiValidation
 } from '../validation/user-kanji-validation.js';
@@ -10,9 +10,9 @@ import {
  * Membuat atau memperbarui progres belajar kanji milik user.
  * Menggunakan operasi upsert untuk menangani penambahan baru atau pembaruan.
  */
-const upsert = async (user, request) => {
+const add = async (user, request) => {
     // Validasi input data progres
-    const validatedRequest = createOrUpdateUserKanjiValidation.parse(request);
+    const validatedRequest = addUserKanjiValidation.parse(request);
 
     // Memastikan data kanji yang direferensikan memang ada di database
     const kanjiCount = await prisma.kanji.count({
@@ -36,7 +36,8 @@ const upsert = async (user, request) => {
     let memorizedAt = existing?.memorizedAt;
 
     // Logika penentuan tanggal hafal: diatur saat pertama kali ditandai sebagai 'memorized'
-    if (validatedRequest.isMemorized === true && !existing?.isMemorized) {
+    // Karena sekarang di-hardcode menjadi true, maka set memorizedAt jika sebelumnya belum memorized
+    if (!existing?.isMemorized) {
         memorizedAt = now;
     }
 
@@ -49,22 +50,22 @@ const upsert = async (user, request) => {
             }
         },
         update: {
-            isMemorized: validatedRequest.isMemorized ?? existing?.isMemorized,
+            isMemorized: true, // Hardcoded to true
             difficulty: validatedRequest.difficulty ?? existing?.difficulty,
             note: validatedRequest.note ?? existing?.note,
-            reviewCount: { increment: 1 }, // Menambah hitungan review setiap kali di-update
+            reviewCount: { increment: 1 },
             lastReviewed: now,
             memorizedAt: memorizedAt
         },
         create: {
             userId: user.id,
             kanjiId: validatedRequest.kanjiId,
-            isMemorized: validatedRequest.isMemorized || false,
+            isMemorized: true, // Hardcoded to true
             difficulty: validatedRequest.difficulty,
             note: validatedRequest.note,
             reviewCount: 1,
             lastReviewed: now,
-            memorizedAt: validatedRequest.isMemorized ? now : null
+            memorizedAt: now
         }
     });
 };
@@ -143,4 +144,4 @@ const list = async (user, request) => {
     };
 };
 
-export { upsert, get, list };
+export { add, get, list };

--- a/backend/src/validation/user-kanji-validation.js
+++ b/backend/src/validation/user-kanji-validation.js
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Skema validasi untuk membuat atau memperbarui progres belajar kanji.
  */
-const createOrUpdateUserKanjiValidation = z.object({
+const addUserKanjiValidation = z.object({
     kanjiId: z.string().uuid("Format ID Kanji tidak valid"),
     isMemorized: z.boolean().optional(),
     difficulty: z.number().min(1, "Tingkat kesulitan minimal 1").max(5, "Tingkat kesulitan maksimal 5").optional(),
@@ -25,7 +25,7 @@ const listUserKanjiValidation = z.object({
 });
 
 export {
-    createOrUpdateUserKanjiValidation,
+    addUserKanjiValidation,
     getUserKanjiValidation,
     listUserKanjiValidation
 };

--- a/backend/tests/user-kanji-test.js
+++ b/backend/tests/user-kanji-test.js
@@ -95,8 +95,8 @@ describe("User Kanji API", () => {
         });
     });
 
-    describe("POST/PUT /api/user-kanji (Upsert)", () => {
-        it("seharusnya berhasil mengupdate hafalan kanji lewat body parameter", async () => {
+    describe("POST /api/user-kanji/:kanjiId (Add Progress)", () => {
+        it("seharusnya berhasil menambah hafalan kanji lewat url parameter tanpa body", async () => {
             mockAuthSuccess();
             
             prismaMock.kanji.count.mockResolvedValue(1);
@@ -106,21 +106,19 @@ describe("User Kanji API", () => {
             });
 
             const response = await request(app)
-                .post("/api/user-kanji")
+                .post("/api/user-kanji/123e4567-e89b-12d3-a456-426614174003")
                 .set("Authorization", "Bearer valid-token")
-                .send({
-                    kanjiId: "123e4567-e89b-12d3-a456-426614174003",
-                    isMemorized: true
-                });
+                .send({}); // Body kosong
 
             expect(response.status).toBe(200);
             expect(response.body.data.isMemorized).toBe(true);
             expect(prismaMock.userKanji.upsert).toHaveBeenCalledWith(expect.objectContaining({
-                 where: { userId_kanjiId: { userId: "user-1", kanjiId: "123e4567-e89b-12d3-a456-426614174003" } }
+                 where: { userId_kanjiId: { userId: "user-1", kanjiId: "123e4567-e89b-12d3-a456-426614174003" } },
+                 create: expect.objectContaining({ isMemorized: true })
             }));
         });
 
-        it("seharusnya berhasil mengupdate hafalan kanji lewat url parameter", async () => {
+        it("seharusnya tetap berhasil mengupdate hafalan kanji jika sudah ada", async () => {
             mockAuthSuccess();
             prismaMock.kanji.count.mockResolvedValue(1);
             prismaMock.userKanji.findUnique.mockResolvedValue({ isMemorized: false }); 
@@ -129,14 +127,12 @@ describe("User Kanji API", () => {
             });
 
             const response = await request(app)
-                .put("/api/user-kanji/123e4567-e89b-12d3-a456-426614174004")
-                .set("Authorization", "Bearer valid-token")
-                .send({
-                    isMemorized: true
-                });
+                .post("/api/user-kanji/123e4567-e89b-12d3-a456-426614174004")
+                .set("Authorization", "Bearer valid-token");
 
             expect(response.status).toBe(200);
             expect(response.body.data.kanjiId).toBe("123e4567-e89b-12d3-a456-426614174004");
+            expect(response.body.data.isMemorized).toBe(true);
         });
 
         it("seharusnya gagal di-update (404) jika kanjinya fiktif/tidak ada", async () => {
@@ -144,12 +140,8 @@ describe("User Kanji API", () => {
             prismaMock.kanji.count.mockResolvedValue(0);
 
             const response = await request(app)
-                .post("/api/user-kanji")
-                .set("Authorization", "Bearer valid-token")
-                .send({
-                    kanjiId: "123e4567-e89b-12d3-a456-426614174005",
-                    isMemorized: true
-                });
+                .post("/api/user-kanji/123e4567-e89b-12d3-a456-426614174005")
+                .set("Authorization", "Bearer valid-token");
 
             expect(response.status).toBe(404);
             expect(prismaMock.userKanji.upsert).not.toHaveBeenCalled();

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,48 @@
+# Refactor: Simpan Progress User Kanji Tanpa Request Body
+
+## 1. Background & Alasan Refaktor
+Saat ini, proses penyimpanan progres hafalan kanji (`user-kanji`) menggunakan dua endpoint: `POST /api/user-kanji` (body-based) dan `PUT /api/user-kanji/:kanjiId` (path-based). Penggunaan `PUT` dengan request body dianggap kurang efisien untuk skenario "Quick Add" di mana pengguna hanya perlu memilih kanji untuk menandainya sebagai "sudah dihafal".
+
+Refaktor ini bertujuan untuk menyederhanakan interaksi API dengan menghapus kebutuhan request body dan memindahkan metode simpan progres ke `POST /api/user-kanji/:kanjiId`. Status `isMemorized` akan di-hardcode menjadi `true` pada saat penyimpanan karena asumsi utama pemanggilan endpoint ini adalah untuk menandai progres berhasil dihafalkan.
+
+## 2. Perubahan Yang Diperlukan (Before vs After)
+
+### A. `backend/src/routes/api.js`
+- **Before**: 
+  ```javascript
+  apiRouter.post('/api/user-kanji', userKanjiController.upsert);
+  apiRouter.put('/api/user-kanji/:kanjiId', userKanjiController.upsert);
+  ```
+- **After**:
+  ```javascript
+  apiRouter.post('/api/user-kanji/:kanjiId', userKanjiController.upsert);
+  // (Menghapus metode PUT dan POST lama yang berbasis body)
+  ```
+
+### B. `backend/src/controller/user-kanji-controller.js`
+- **Before**: Mengambil data dari `req.body` dan menimpa `kanjiId` dari params.
+- **After**: Menginisialisasi objek request meskipun `req.body` tidak ada, lalu mengambil `kanjiId` dari `req.params`.
+
+### C. `backend/src/services/user-kanji-service.js`
+- **Before**: Menggunakan `validatedRequest.isMemorized` dari input body (default false).
+- **After**: Memaksa variabel `isMemorized` bernilai `true` saat menjalankan `upsert` ke database.
+
+### D. `backend/src/validation/user-kanji-validation.js`
+- **Before**: `kanjiId` wajib ada di skema objek body.
+- **After**: Menyesuaikan skema agar tetap valid meskipun body kosong (karena `kanjiId` diinjeksi oleh controller dari URL).
+
+## 3. Step-by-Step Implementasi
+
+1.  **Update Validation**: Modifikasi `listUserKanjiValidation` atau buat skema baru jika perlu agar parameter body bersifat opsional.
+2.  **Logic Update di Service**: Ubah `user-kanji-service.js` fungsi `upsert` untuk mengabaikan status hafalan dari luar dan selalu mensetnya ke `true`. Pastikan `difficulty` dan `note` tetap `null` jika tidak ada.
+3.  **Refaktor Controller**: Sesuaikan `user-kanji-controller.js` guna menangani request tanpa body.
+4.  **Update Endpoint Routing**: Ganti `apiRouter.put` menjadi `apiRouter.post` pada file `api.js`.
+5.  **Pembersihan**: Hapus route `POST /api/user-kanji` yang lama jika sudah tidak digunakan.
+
+## 4. Acceptance Criteria
+- [ ] Endpoint `PUT /api/user-kanji/:kanjiId` diganti menjadi `POST /api/user-kanji/:kanjiId`.
+- [ ] Request tanpa body ke `POST /api/user-kanji/:kanjiId` berhasil menyimpan data.
+- [ ] Hasil simpan otomatis memiliki status `isMemorized: true`.
+- [ ] Field `difficulty` dan `note` tetap `null` secara default.
+- [ ] Format response data tidak berubah (konsistensi API tetap terjaga).
+- [ ] Tidak ada perubahan pada file di luar scope `user-kanji`.


### PR DESCRIPTION
# Refactor: Simpan Progress User Kanji Tanpa Request Body

## 1. Background & Alasan Refaktor
Saat ini, proses penyimpanan progres hafalan kanji (`user-kanji`) menggunakan dua endpoint: `POST /api/user-kanji` (body-based) dan `PUT /api/user-kanji/:kanjiId` (path-based). Penggunaan `PUT` dengan request body dianggap kurang efisien untuk skenario "Quick Add" di mana pengguna hanya perlu memilih kanji untuk menandainya sebagai "sudah dihafal".

Refaktor ini bertujuan untuk menyederhanakan interaksi API dengan menghapus kebutuhan request body dan memindahkan metode simpan progres ke `POST /api/user-kanji/:kanjiId`. Status `isMemorized` akan di-hardcode menjadi `true` pada saat penyimpanan karena asumsi utama pemanggilan endpoint ini adalah untuk menandai progres berhasil dihafalkan.

## 2. Perubahan Yang Diperlukan (Before vs After)

### A. `backend/src/routes/api.js`
- **Before**: 
  ```javascript
  apiRouter.post('/api/user-kanji', userKanjiController.upsert);
  apiRouter.put('/api/user-kanji/:kanjiId', userKanjiController.upsert);
  ```
- **After**:
  ```javascript
  apiRouter.post('/api/user-kanji/:kanjiId', userKanjiController.upsert);
  // (Menghapus metode PUT dan POST lama yang berbasis body)
  ```

### B. `backend/src/controller/user-kanji-controller.js`
- **Before**: Mengambil data dari `req.body` dan menimpa `kanjiId` dari params.
- **After**: Menginisialisasi objek request meskipun `req.body` tidak ada, lalu mengambil `kanjiId` dari `req.params`.

### C. `backend/src/services/user-kanji-service.js`
- **Before**: Menggunakan `validatedRequest.isMemorized` dari input body (default false).
- **After**: Memaksa variabel `isMemorized` bernilai `true` saat menjalankan `upsert` ke database.

### D. `backend/src/validation/user-kanji-validation.js`
- **Before**: `kanjiId` wajib ada di skema objek body.
- **After**: Menyesuaikan skema agar tetap valid meskipun body kosong (karena `kanjiId` diinjeksi oleh controller dari URL).

## 3. Step-by-Step Implementasi

1.  **Update Validation**: Modifikasi `listUserKanjiValidation` atau buat skema baru jika perlu agar parameter body bersifat opsional.
2.  **Logic Update di Service**: Ubah `user-kanji-service.js` fungsi `upsert` untuk mengabaikan status hafalan dari luar dan selalu mensetnya ke `true`. Pastikan `difficulty` dan `note` tetap `null` jika tidak ada.
3.  **Refaktor Controller**: Sesuaikan `user-kanji-controller.js` guna menangani request tanpa body.
4.  **Update Endpoint Routing**: Ganti `apiRouter.put` menjadi `apiRouter.post` pada file `api.js`.
5.  **Pembersihan**: Hapus route `POST /api/user-kanji` yang lama jika sudah tidak digunakan.

## 4. Acceptance Criteria
- [ ] Endpoint `PUT /api/user-kanji/:kanjiId` diganti menjadi `POST /api/user-kanji/:kanjiId`.
- [ ] Request tanpa body ke `POST /api/user-kanji/:kanjiId` berhasil menyimpan data.
- [ ] Hasil simpan otomatis memiliki status `isMemorized: true`.
- [ ] Field `difficulty` dan `note` tetap `null` secara default.
- [ ] Format response data tidak berubah (konsistensi API tetap terjaga).
- [ ] Tidak ada perubahan pada file di luar scope `user-kanji`.
